### PR TITLE
add four related ACL 2025 papers from Yale NLP lab

### DIFF
--- a/paper.html
+++ b/paper.html
@@ -67,6 +67,7 @@
 <li><i><b>Hierarchical attention graph for scientific document summarization in global and local level</b></i>, Zhao et al., <a href="https://arxiv.org/abs/2405.10202" target="_blank"><img src="https://img.shields.io/badge/arXiv-2024.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>Can Large Language Model Summarizers Adapt to Diverse Scientific Communication Goals?</b></i>, Fonseca et al., <a href="https://aclanthology.org/2024.findings-acl.508/" target="_blank"><img src="https://img.shields.io/badge/PDF-2024.08-blue" alt="PDF Badge"></a></li>
 <li><i><b>Autonomous LLM-Driven Research—from Data to Human-Verifiable Research Papers</b></i>, Ifargan et al., <img src="https://img.shields.io/badge/NEJM AI-2025-green" alt="NEJM AI Badge"></li>
+<li><i><b>AbGen: Evaluating Large Language Models in Ablation Study Design and Evaluation for Scientific Research</b></i>, Zhao et al., <a href="https://arxiv.org/pdf/2507.13300" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
 </ul>
 
 <b>Self-Questioning & Self-Reflection Automatic Scientific Comprehension</b>
@@ -125,6 +126,8 @@
 <li><i><b>ChartGemma: Visual Instruction-tuning for Chart Reasoning in the Wild</b></i>, Masry et al., <a href="https://aclanthology.org/2025.coling-industry.54/" target="_blank"><img src="https://img.shields.io/badge/PDF-2025.01-blue" alt="PDF Badge"></a></li>
 <li><i><b>ChartSketcher: Reasoning with Multimodal Feedback and Reflection for Chart Understanding</b></i>, Huang et al., <a href="https://arxiv.org/abs/2505.19076" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>Multimodal DeepResearcher: Generating Text-Chart Interleaved Reports From Scratch with Agentic Framework</b></i>, Yang et al., <a href="https://arxiv.org/abs/2506.02454" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.06-red" alt="arXiv Badge"></a></li>
+<li><i><b>SciVer: Evaluating Foundation Models for Multimodal Scientific Claim Verification</b></i>, Wang et al., <a href="https://arxiv.org/pdf/2506.15569v1" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
+<li><i><b>Can Multimodal Foundation Models Understand Schematic Diagrams? An Empirical Study on Information-Seeking QA over Scientific Papers</b></i>, Zhao et al., <a href="https://arxiv.org/pdf/2507.10787" target="_blank"><img src="https://img.shields.io/badge/ACL Findings-2021-green" alt="ACL Findings Badge"></a></li>
 </ul>
 
 </ul>
@@ -924,6 +927,7 @@
 <li><i><b>The ai scientist: Towards fully automated open-ended scientific discovery</b></i>, Lu et al., <a href="https://arxiv.org/abs/2408.06292" target="_blank"><img src="https://img.shields.io/badge/arXiv-2024.08-red" alt="arXiv Badge"></a></li>
 <li><i><b>SEAGraph: Unveiling the Whole Story of Paper Review Comments</b></i>, Yu et al., <a href="https://arxiv.org/abs/2412.11939" target="_blank"><img src="https://img.shields.io/badge/arXiv-2024.12-red" alt="arXiv Badge"></a></li>
 <li><i><b>The ai scientist-v2: Workshop-level automated scientific discovery via agentic tree search</b></i>, Yamada et al., <a href="https://arxiv.org/abs/2504.08066" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.04-red" alt="arXiv Badge"></a></li>
+<li><i><b>Can LLMs Identify Critical Limitations within Scientific Research? A Systematic Evaluation on AI Research Papers</b></i>, Xu et al., <a href="https://arxiv.org/pdf/2507.02694" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
 </ul>
 
 <b>Unified Generation</b>
@@ -1591,6 +1595,8 @@
 <li><i><b>CharXiv: Charting Gaps in Realistic Chart Understanding in Multimodal LLMs</b></i>, Wang et al., <a href="https://proceedings.neurips.cc/paper_files/paper/2024/file/cdf6f8e9fd9aeaf79b6024caec24f15b-Paper-Datasets_and_Benchmarks_Track.pdf" target="_blank"><img src="https://img.shields.io/badge/PDF-2024.12-blue" alt="PDF Badge"></a></li>
 <li><i><b>The Mighty ToRR: A Benchmark for Table Reasoning and Robustness</b></i>, Ashury-Tahan et al., <a href="https://arxiv.org/abs/2502.19412" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.02-red" alt="arXiv Badge"></a></li>
 <li><i><b>Tablebench: A comprehensive and complex benchmark for table question answering</b></i>, Wu et al., <img src="https://img.shields.io/badge/AAAI-2025-green" alt="AAAI Badge"></li>
+<li><i><b>SciVer: Evaluating Foundation Models for Multimodal Scientific Claim Verification</b></i>, Wang et al., <a href="https://arxiv.org/pdf/2506.15569v1" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
+<li><i><b>Can Multimodal Foundation Models Understand Schematic Diagrams? An Empirical Study on Information-Seeking QA over Scientific Papers</b></i>, Zhao et al., <a href="https://arxiv.org/pdf/2507.10787" target="_blank"><img src="https://img.shields.io/badge/ACL Findings-2021-green" alt="ACL Findings Badge"></a></li>
 </ul>
 
 
@@ -1688,6 +1694,7 @@
 <li><i><b>MLR-Bench: Evaluating AI Agents on Open-Ended Machine Learning Research</b></i>, Chen et al., <a href="https://arxiv.org/abs/2505.19955" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>Autobio: A simulation and benchmark for robotic automation in digital biology laboratory</b></i>, Lan et al., <a href="https://arxiv.org/abs/2505.14030" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>ResearchCodeBench: Benchmarking LLMs on Implementing Novel Machine Learning Research Code</b></i>, Hua et al., <a href="https://arxiv.org/abs/2506.02314" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.06-red" alt="arXiv Badge"></a></li>
+<li><i><b>AbGen: Evaluating Large Language Models in Ablation Study Design and Evaluation for Scientific Research</b></i>, Zhao et al., <a href="https://arxiv.org/pdf/2507.13300" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
 </ul>
 
 <b>Experimental Analysis</b>
@@ -1795,4 +1802,5 @@
 <li><i><b>When AI co-scientists fail: SPOT-a benchmark for automated verification of scientific research</b></i>, Son et al., <a href="https://arxiv.org/abs/2505.11855" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>Re <sup>2</sup>: A Consistency-ensured Dataset for Full-stage Peer Review and Multi-turn Rebuttal Discussions</b></i>, Zhang et al., <a href="https://arxiv.org/abs/2505.07920" target="_blank"><img src="https://img.shields.io/badge/arXiv-2025.05-red" alt="arXiv Badge"></a></li>
 <li><i><b>PaperEval: A universal, quantitative, and explainable paper evaluation method powered by a multi-agent system</b></i>, Huang et al., <img src="https://img.shields.io/badge/Information Processing & Management-2025-green" alt="Information Processing & Management Badge"></li>
+<li><i><b>Can LLMs Identify Critical Limitations within Scientific Research? A Systematic Evaluation on AI Research Papers</b></i>, Xu et al., <a href="https://arxiv.org/pdf/2507.02694" target="_blank"><img src="https://img.shields.io/badge/ACL-2025-green" alt="ACL Badge"></a></li>
 </ul>


### PR DESCRIPTION
Thanks to @LightChen233 for creating and maintaining this awesome paper list!

This PR adds four recent papers from Yale NLP lab:

**To Section 1.2 Table & Chart Scientific Comprehension and Section 9.1**
- [*SciVer: Evaluating Foundation Models for Multimodal Scientific Claim Verification*](https://arxiv.org/abs/2506.15569) (ACL 2025)  
- [*Can Multimodal Foundation Models Understand Schematic Diagrams? An Empirical Study on Information-Seeking QA over Scientific Papers*](https://www.arxiv.org/abs/2507.10787) (ACL 2025 Findings)  

**To Section 3.4.8 Experiment Design and Section 9.3**
- [*AbGen: Evaluating Large Language Models in Ablation Study Design and Evaluation for Scientific Research*](https://arxiv.org/abs/2507.13300) (ACL 2025)

**To Section 5.2.3 Peer-Review and Section 9.5**
- [*Can LLMs Identify Critical Limitations within Scientific Research? A Systematic Evaluation on AI Research Papers*](https://arxiv.org/abs/2507.02694) (ACL 2025)

Let me know if any edits are needed!
